### PR TITLE
Add LSM6DSOX example

### DIFF
--- a/LKExp-mbed-x-nucleo-iks01a2/README.md
+++ b/LKExp-mbed-x-nucleo-iks01a2/README.md
@@ -11,6 +11,8 @@ Run mbed examples with X\_NUCLEO\_IKS01A2 board, especially motion MEMS.
 
 To display in other IRQ : [Simplify your code with mbed events](https://os.mbed.com/blog/entry/Simplify-your-code-with-mbed-events/)
 
+Autre source de drivers, hors mbed (fournie par Ladislas) : <https://github.com/STMicroelectronics/STMems_Standard_C_drivers>
+
 ### LSM6DSOX
 To use LSM6DSOX on the STEVAL-MKI197V1 with X-NUCLEO-IKS01A2:
 

--- a/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.cpp
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.cpp
@@ -1,0 +1,122 @@
+/**
+ ******************************************************************************
+ * @file    XNucleoIKS01A2.cpp
+ * @author  CLab
+ * @version V1.0.0
+ * @date    9-August-2016
+ * @brief   Implementation file for the X_NUCLEO_IKS01A2 singleton class
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+*/ 
+    
+/* Includes ------------------------------------------------------------------*/
+#include "mbed.h"
+#include "XNucleoIKS01A2.h"
+
+/* Static variables ----------------------------------------------------------*/
+XNucleoIKS01A2 *XNucleoIKS01A2::_instance = NULL;
+
+
+/* Methods -------------------------------------------------------------------*/
+/**
+ * @brief  Constructor
+ */
+XNucleoIKS01A2::XNucleoIKS01A2(DevI2C *ext_i2c, PinName int1, PinName int2) : dev_i2c(ext_i2c),
+    ht_sensor(new HTS221Sensor(dev_i2c)),
+    magnetometer(new LSM303AGRMagSensor(dev_i2c)),
+    accelerometer(new LSM303AGRAccSensor(dev_i2c)),
+    pt_sensor(new LPS22HBSensor(dev_i2c)),
+    acc_gyro(new LSM6DSLSensor(dev_i2c, LSM6DSL_ACC_GYRO_I2C_ADDRESS_HIGH, int1, int2))
+{ 
+  ht_sensor->init(NULL);
+  magnetometer->init(NULL);
+  accelerometer->init(NULL);
+  pt_sensor->init(NULL);
+  acc_gyro->init(NULL);
+}
+
+/**
+ * @brief     Get singleton instance
+ * @return    a pointer to the initialized singleton instance of class XNucleoIKS01A2.
+ *            A return value of NULL indicates an out of memory situation.
+ * @param[in] ext_i2c (optional) pointer to an instance of DevI2C to be used
+ *            for communication on the expansion board. 
+ *            Defaults to NULL.
+ *            Taken into account only on the very first call of one of the 'Instance' functions.
+ *            If not provided a new DevI2C will be created with standard
+ *            configuration parameters.
+ *            The used DevI2C object gets saved in instance variable dev_i2c.
+ * @param[in] int1 LSM6DSL INT1 pin.
+ *            Taken into account only on the very first call of one of the 'Instance' functions.
+ *            It maps the INT1 pin for LSM6DSL. Defaults to IKS01A2_PIN_LSM6DSL_INT1.
+ * @param[in] int2 LSM6DSL INT1 pin.
+ *            Taken into account only on the very first call of one of the 'Instance' functions.
+ *            It maps the INT2 pin for LSM6DSL. Defaults to IKS01A2_PIN_LSM6DSL_INT2.
+ */
+XNucleoIKS01A2 *XNucleoIKS01A2::instance(DevI2C *ext_i2c, PinName int1, PinName int2) {
+    if(_instance == NULL) {
+        if(ext_i2c == NULL)
+            ext_i2c = new DevI2C(IKS01A2_PIN_I2C_SDA, IKS01A2_PIN_I2C_SCL);
+
+        if(ext_i2c != NULL)
+            _instance = new XNucleoIKS01A2(ext_i2c, int1, int2);
+    }
+
+    return _instance;
+}
+
+/**
+ * @brief     Get singleton instance
+ * @return    a pointer to the initialized singleton instance of class X_NUCLEO_IKS01A1.
+ *            A return value of NULL indicates an out of memory situation.
+ * @param[in] sda I2C data line pin.
+ *            Taken into account only on the very first call of one of the 'Instance' functions.
+ *            A new DevI2C will be created based on parameters 'sda' and 'scl'.
+ *            The used DevI2C object gets saved in instance variable dev_i2c.
+ * @param[in] scl I2C clock line pin.
+ *            Taken into account only on the very first call of one of the 'Instance' functions.
+ *            A new DevI2C will be created based on parameters 'sda' and 'scl'.
+ *            The used DevI2C object gets saved in instance variable dev_i2c.
+ * @param[in] int1 LSM6DSL INT1 pin.
+ *            Taken into account only on the very first call of one of the 'Instance' functions.
+ *            It maps the INT1 pin for LSM6DSL. Defaults to IKS01A2_PIN_LSM6DSL_INT1.
+ * @param[in] int2 LSM6DSL INT1 pin.
+ *            Taken into account only on the very first call of one of the 'Instance' functions.
+ *            It maps the INT2 pin for LSM6DSL. Defaults to IKS01A2_PIN_LSM6DSL_INT2.
+ */
+XNucleoIKS01A2 *XNucleoIKS01A2::instance(PinName sda, PinName scl, PinName int1, PinName int2) {
+    if(_instance == NULL) {
+        DevI2C *ext_i2c = new DevI2C(sda, scl);
+
+        if(ext_i2c != NULL)
+            _instance = new XNucleoIKS01A2(ext_i2c, int1, int2);
+    }
+
+    return _instance;
+}

--- a/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.cpp
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.cpp
@@ -54,13 +54,21 @@ XNucleoIKS01A2_Extension::XNucleoIKS01A2_Extension(DevI2C *ext_i2c, PinName int1
     pt_sensor(new LPS22HBSensor(dev_i2c)),
     acc_gyro(new LSM6DSLSensor(dev_i2c, LSM6DSL_ACC_GYRO_I2C_ADDRESS_HIGH, int1, int2)),
     acc_gyro_ext(new LSM6DSOXSensor(dev_i2c, LSM6DSOX_I2C_ADD_L, int1_ext, int2_ext))
-{ 
+{
+  uint8_t error;
   ht_sensor->init(NULL);
   magnetometer->init(NULL);
   accelerometer->init(NULL);
   pt_sensor->init(NULL);
   acc_gyro->init(NULL);
-  acc_gyro_ext->init(NULL);
+  error = acc_gyro_ext->init(NULL);
+  
+  if (error)
+  {
+      uint8_t id;
+      acc_gyro_ext->read_id(&id);
+      printf("\nError in initialization of LSM6DSOX, I2C address read is 0x%X", id);
+  }
 }
 
 /**

--- a/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.cpp
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.cpp
@@ -37,28 +37,30 @@
     
 /* Includes ------------------------------------------------------------------*/
 #include "mbed.h"
-#include "XNucleoIKS01A2.h"
+#include "XNucleoIKS01A2_Extension.h"
 
 /* Static variables ----------------------------------------------------------*/
-XNucleoIKS01A2 *XNucleoIKS01A2::_instance = NULL;
+XNucleoIKS01A2_Extension *XNucleoIKS01A2_Extension::_instance = NULL;
 
 
 /* Methods -------------------------------------------------------------------*/
 /**
  * @brief  Constructor
  */
-XNucleoIKS01A2::XNucleoIKS01A2(DevI2C *ext_i2c, PinName int1, PinName int2) : dev_i2c(ext_i2c),
+XNucleoIKS01A2_Extension::XNucleoIKS01A2_Extension(DevI2C *ext_i2c, PinName int1, PinName int2, PinName int1_ext, PinName int2_ext) : dev_i2c(ext_i2c),
     ht_sensor(new HTS221Sensor(dev_i2c)),
     magnetometer(new LSM303AGRMagSensor(dev_i2c)),
     accelerometer(new LSM303AGRAccSensor(dev_i2c)),
     pt_sensor(new LPS22HBSensor(dev_i2c)),
-    acc_gyro(new LSM6DSLSensor(dev_i2c, LSM6DSL_ACC_GYRO_I2C_ADDRESS_HIGH, int1, int2))
+    acc_gyro(new LSM6DSLSensor(dev_i2c, LSM6DSL_ACC_GYRO_I2C_ADDRESS_HIGH, int1, int2)),
+    acc_gyro_ext(new LSM6DSOXSensor(dev_i2c, LSM6DSOX_I2C_ADD_L, int1_ext, int2_ext))
 { 
   ht_sensor->init(NULL);
   magnetometer->init(NULL);
   accelerometer->init(NULL);
   pt_sensor->init(NULL);
   acc_gyro->init(NULL);
+  acc_gyro_ext->init(NULL);
 }
 
 /**
@@ -79,13 +81,13 @@ XNucleoIKS01A2::XNucleoIKS01A2(DevI2C *ext_i2c, PinName int1, PinName int2) : de
  *            Taken into account only on the very first call of one of the 'Instance' functions.
  *            It maps the INT2 pin for LSM6DSL. Defaults to IKS01A2_PIN_LSM6DSL_INT2.
  */
-XNucleoIKS01A2 *XNucleoIKS01A2::instance(DevI2C *ext_i2c, PinName int1, PinName int2) {
+XNucleoIKS01A2_Extension *XNucleoIKS01A2_Extension::instance(DevI2C *ext_i2c, PinName int1, PinName int2, PinName int1_ext, PinName int2_ext) {
     if(_instance == NULL) {
         if(ext_i2c == NULL)
             ext_i2c = new DevI2C(IKS01A2_PIN_I2C_SDA, IKS01A2_PIN_I2C_SCL);
 
         if(ext_i2c != NULL)
-            _instance = new XNucleoIKS01A2(ext_i2c, int1, int2);
+            _instance = new XNucleoIKS01A2_Extension(ext_i2c, int1, int2, int1_ext, int2_ext);
     }
 
     return _instance;
@@ -110,12 +112,12 @@ XNucleoIKS01A2 *XNucleoIKS01A2::instance(DevI2C *ext_i2c, PinName int1, PinName 
  *            Taken into account only on the very first call of one of the 'Instance' functions.
  *            It maps the INT2 pin for LSM6DSL. Defaults to IKS01A2_PIN_LSM6DSL_INT2.
  */
-XNucleoIKS01A2 *XNucleoIKS01A2::instance(PinName sda, PinName scl, PinName int1, PinName int2) {
+XNucleoIKS01A2_Extension *XNucleoIKS01A2_Extension::instance(PinName sda, PinName scl, PinName int1, PinName int2, PinName int1_ext, PinName int2_ext) {
     if(_instance == NULL) {
         DevI2C *ext_i2c = new DevI2C(sda, scl);
 
         if(ext_i2c != NULL)
-            _instance = new XNucleoIKS01A2(ext_i2c, int1, int2);
+            _instance = new XNucleoIKS01A2_Extension(ext_i2c, int1, int2, int1_ext, int2_ext);
     }
 
     return _instance;

--- a/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.h
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.h
@@ -1,0 +1,107 @@
+/**
+ ******************************************************************************
+ * @file    XNucleoIKS01A2.h
+ * @author  CLab
+ * @version V1.0.0
+ * @date    9-August-2016
+ * @brief   Header file for class XNucleoIKS01A2 representing a X-NUCLEO-IKS01A2
+ *          expansion board
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+/* Define to prevent from recursive inclusion --------------------------------*/
+#ifndef __X_NUCLEO_IKS01A2_H
+#define __X_NUCLEO_IKS01A2_H
+
+/* Includes ------------------------------------------------------------------*/
+#include "mbed.h"
+#include "x_nucleo_iks01a2_targets.h"
+#include "HTS221Sensor.h"
+#include "LSM303AGRAccSensor.h"
+#include "LSM303AGRMagSensor.h"
+#include "LPS22HBSensor.h"
+#include "LSM6DSLSensor.h"
+#include "DevI2C.h"
+
+/* Macros -------------------------------------------------------------------*/
+#define CALL_METH(obj, meth, param, ret) ((obj == NULL) ?       \
+                      ((*(param) = (ret)), 0) : \
+                      ((obj)->meth(param))      \
+                      )
+
+/* Classes -------------------------------------------------------------------*/
+/** Class XNucleoIKS01A2 is intended to represent the MEMS Inertial & Environmental 
+ *  Nucleo Expansion Board with the same name.
+ *
+ *  The expansion board is featuring basically four IPs:\n
+ *  -# a HTS221 Relative Humidity and Temperature Sensor\n
+ *  -# a LSM303AGR 3-Axis Magnetometer and 3D Acceleromenter\n
+ *  -# a LPS22HB MEMS Pressure Sensor (and Temperature Sensor)\n
+ *  -# and a LSM6DSL 3D Acceleromenter and 3D Gyroscope\n
+ *
+ * The expansion board features also a DIL 24-pin socket which makes it possible
+ * to add further MEMS adapters and other sensors (e.g. UV index). 
+ *
+ * It is intentionally implemented as a singleton because only one
+ * X_NUCLEO_IKS01A2 at a time might be deployed in a HW component stack.\n
+ * In order to get the singleton instance you have to call class method `Instance()`, 
+ * e.g.:
+ * @code
+ * // Inertial & Environmental expansion board singleton instance
+ * static X_NUCLEO_IKS01A2 *<TODO>_expansion_board = X_NUCLEO_IKS01A2::Instance();
+ * @endcode
+ */
+class XNucleoIKS01A2
+{
+ protected:
+    XNucleoIKS01A2(DevI2C *ext_i2c, PinName int1, PinName int2);
+
+    ~XNucleoIKS01A2(void) {
+        /* should never be called */
+        error("Trial to delete XNucleoIKS01A2 singleton!\n");
+    }
+
+ public:
+    static XNucleoIKS01A2* instance(DevI2C *ext_i2c = NULL, PinName int1 = IKS01A2_PIN_LSM6DSL_INT1, PinName int2 = IKS01A2_PIN_LSM6DSL_INT2);
+    static XNucleoIKS01A2* instance(PinName sda, PinName scl, PinName int1 = IKS01A2_PIN_LSM6DSL_INT1, PinName int2 = IKS01A2_PIN_LSM6DSL_INT2);
+
+    DevI2C  *dev_i2c;
+
+    HTS221Sensor  *ht_sensor;
+    LSM303AGRMagSensor *magnetometer;
+    LSM303AGRAccSensor *accelerometer;
+    LPS22HBSensor  *pt_sensor;
+    LSM6DSLSensor *acc_gyro;
+
+ private:
+    static XNucleoIKS01A2 *_instance;
+};
+
+#endif /* __X_NUCLEO_IKS01A2_H */

--- a/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.h
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/XNucleoIKS01A2_Extension.h
@@ -37,17 +37,18 @@
  */
 
 /* Define to prevent from recursive inclusion --------------------------------*/
-#ifndef __X_NUCLEO_IKS01A2_H
-#define __X_NUCLEO_IKS01A2_H
+#ifndef __X_NUCLEO_IKS01A2_EXTENSION_H
+#define __X_NUCLEO_IKS01A2_EXTENSION_H
 
 /* Includes ------------------------------------------------------------------*/
 #include "mbed.h"
-#include "x_nucleo_iks01a2_targets.h"
+#include "x_nucleo_iks01a2_extension_targets.h"
 #include "HTS221Sensor.h"
 #include "LSM303AGRAccSensor.h"
 #include "LSM303AGRMagSensor.h"
 #include "LPS22HBSensor.h"
 #include "LSM6DSLSensor.h"
+#include "LSM6DSOXSensor.h"
 #include "DevI2C.h"
 
 /* Macros -------------------------------------------------------------------*/
@@ -78,19 +79,19 @@
  * static X_NUCLEO_IKS01A2 *<TODO>_expansion_board = X_NUCLEO_IKS01A2::Instance();
  * @endcode
  */
-class XNucleoIKS01A2
+class XNucleoIKS01A2_Extension
 {
  protected:
-    XNucleoIKS01A2(DevI2C *ext_i2c, PinName int1, PinName int2);
+    XNucleoIKS01A2_Extension(DevI2C *ext_i2c, PinName int1, PinName int2, PinName int1_ext, PinName int2_ext);
 
-    ~XNucleoIKS01A2(void) {
+    ~XNucleoIKS01A2_Extension(void) {
         /* should never be called */
         error("Trial to delete XNucleoIKS01A2 singleton!\n");
     }
 
  public:
-    static XNucleoIKS01A2* instance(DevI2C *ext_i2c = NULL, PinName int1 = IKS01A2_PIN_LSM6DSL_INT1, PinName int2 = IKS01A2_PIN_LSM6DSL_INT2);
-    static XNucleoIKS01A2* instance(PinName sda, PinName scl, PinName int1 = IKS01A2_PIN_LSM6DSL_INT1, PinName int2 = IKS01A2_PIN_LSM6DSL_INT2);
+    static XNucleoIKS01A2_Extension* instance(DevI2C *ext_i2c = NULL, PinName int1 = IKS01A2_PIN_LSM6DSL_INT1, PinName int2 = IKS01A2_PIN_LSM6DSL_INT2, PinName int1_ext = PIN_LSM6DSOX_INT1, PinName int2_ext = PIN_LSM6DSOX_INT2);
+    static XNucleoIKS01A2_Extension* instance(PinName sda, PinName scl, PinName int1 = IKS01A2_PIN_LSM6DSL_INT1, PinName int2 = IKS01A2_PIN_LSM6DSL_INT2, PinName int1_ext = PIN_LSM6DSOX_INT1, PinName int2_ext = PIN_LSM6DSOX_INT2);
 
     DevI2C  *dev_i2c;
 
@@ -99,9 +100,10 @@ class XNucleoIKS01A2
     LSM303AGRAccSensor *accelerometer;
     LPS22HBSensor  *pt_sensor;
     LSM6DSLSensor *acc_gyro;
+    LSM6DSOXSensor *acc_gyro_ext;
 
  private:
-    static XNucleoIKS01A2 *_instance;
+    static XNucleoIKS01A2_Extension *_instance;
 };
 
-#endif /* __X_NUCLEO_IKS01A2_H */
+#endif /* __X_NUCLEO_IKS01A2_EXTENSION_H */

--- a/LKExp-mbed-x-nucleo-iks01a2/src/main.cpp
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/main.cpp
@@ -16,6 +16,7 @@
 /* Instantiate the expansion board */
 #if LSM6DSOX_USE
 static XNucleoIKS01A2_Extension *mems_expansion_board = XNucleoIKS01A2_Extension::instance(D14, D15, D4, D5, A5, A4);
+DigitalOut INT_1_LSM6DSOX (PF_9, 0); //Set to 1 to disable I2C and to enable only I3C on LSM6DSOX
 #else
 static XNucleoIKS01A2 *mems_expansion_board = XNucleoIKS01A2::instance(D14, D15, D4, D5);
 #endif

--- a/LKExp-mbed-x-nucleo-iks01a2/src/main.cpp
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/main.cpp
@@ -1,15 +1,24 @@
 # define LCD_DISPLAY 0
+# define LSM6DSOX_USE 0
  
 /* Includes */
 #include "mbed.h"
 #include "show.h"
+#if LSM6DSOX_USE
 #include "XNucleoIKS01A2_Extension.h"
+#else
+#include "XNucleoIKS01A2.h"
+#endif
 #if LCD_DISPLAY
 #include "stm32f769i_discovery_lcd.h"
 #endif
  
 /* Instantiate the expansion board */
+#if LSM6DSOX_USE
 static XNucleoIKS01A2_Extension *mems_expansion_board = XNucleoIKS01A2_Extension::instance(D14, D15, D4, D5, A5, A4);
+#else
+static XNucleoIKS01A2 *mems_expansion_board = XNucleoIKS01A2::instance(D14, D15, D4, D5);
+#endif
  
 
 /* Retrieve the composing elements of the expansion board */
@@ -18,7 +27,9 @@ static HTS221Sensor *hum_temp = mems_expansion_board->ht_sensor;
 static LPS22HBSensor *press_temp = mems_expansion_board->pt_sensor;
 static LSM6DSLSensor *acc_gyro = mems_expansion_board->acc_gyro;
 static LSM303AGRAccSensor *accelerometer = mems_expansion_board->accelerometer;
+#if LSM6DSOX_USE
 static LSM6DSOXSensor *acc_gyro_ext = mems_expansion_board->acc_gyro_ext;
+#endif
 
 DigitalOut myled(LED1);
 Thread eventThread;
@@ -68,8 +79,10 @@ int main() {
   accelerometer->enable();
   acc_gyro->enable_x();
   acc_gyro->enable_g();
+#if LSM6DSOX_USE
   acc_gyro_ext->enable_x();
   acc_gyro_ext->enable_g();
+#endif
   /* Enable Wake-Up Detection. */
   acc_gyro->enable_wake_up_detection();
   
@@ -86,8 +99,10 @@ int main() {
   printf("LSM303AGR accelerometer           = 0x%X\r\n", id);
   acc_gyro->read_id(&id);
   printf("LSM6DSL accelerometer & gyroscope = 0x%X\r\n", id);
+#if LSM6DSOX_USE
   acc_gyro_ext->read_id(&id);
   printf("LSM6DSOX accelerometer & gyroscope = 0x%X\r\n", id);
+#endif
 
 #if LCD_DISPLAY
   BSP_LCD_Init();

--- a/LKExp-mbed-x-nucleo-iks01a2/src/main.cpp
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/main.cpp
@@ -1,5 +1,5 @@
-# define LCD_DISPLAY 0
-# define LSM6DSOX_USE 0
+# define LCD_DISPLAY 1
+# define LSM6DSOX_USE 1
  
 /* Includes */
 #include "mbed.h"
@@ -113,6 +113,15 @@ int main() {
   BSP_LCD_SetFont(&Font24);
   BSP_LCD_DisplayStringAt(0, 0, (uint8_t*)"IMU example", CENTER_MODE);
   BSP_LCD_SetFont(&Font20);
+
+#if LSM6DSOX_USE
+  uint8_t lcd_string[100];
+  sprintf((char*)lcd_string,"LSM6DSOX ID (0x6C expected) : 0x%X               ", id);
+  BSP_LCD_SetTextColor(LCD_COLOR_RED);
+  BSP_LCD_DisplayStringAt(0, 50, (uint8_t*)lcd_string, LEFT_MODE);
+  BSP_LCD_SetTextColor(LCD_COLOR_BLACK);
+#endif
+
 #endif
 
 #if LCD_DISPLAY

--- a/LKExp-mbed-x-nucleo-iks01a2/src/main.cpp
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/main.cpp
@@ -3,13 +3,13 @@
 /* Includes */
 #include "mbed.h"
 #include "show.h"
-#include "XNucleoIKS01A2.h"
+#include "XNucleoIKS01A2_Extension.h"
 #if LCD_DISPLAY
 #include "stm32f769i_discovery_lcd.h"
 #endif
  
 /* Instantiate the expansion board */
-static XNucleoIKS01A2 *mems_expansion_board = XNucleoIKS01A2::instance(D14, D15, D4, D5);
+static XNucleoIKS01A2_Extension *mems_expansion_board = XNucleoIKS01A2_Extension::instance(D14, D15, D4, D5, A5, A4);
  
 
 /* Retrieve the composing elements of the expansion board */
@@ -18,6 +18,7 @@ static HTS221Sensor *hum_temp = mems_expansion_board->ht_sensor;
 static LPS22HBSensor *press_temp = mems_expansion_board->pt_sensor;
 static LSM6DSLSensor *acc_gyro = mems_expansion_board->acc_gyro;
 static LSM303AGRAccSensor *accelerometer = mems_expansion_board->accelerometer;
+static LSM6DSOXSensor *acc_gyro_ext = mems_expansion_board->acc_gyro_ext;
 
 DigitalOut myled(LED1);
 Thread eventThread;
@@ -67,6 +68,8 @@ int main() {
   accelerometer->enable();
   acc_gyro->enable_x();
   acc_gyro->enable_g();
+  acc_gyro_ext->enable_x();
+  acc_gyro_ext->enable_g();
   /* Enable Wake-Up Detection. */
   acc_gyro->enable_wake_up_detection();
   
@@ -83,6 +86,8 @@ int main() {
   printf("LSM303AGR accelerometer           = 0x%X\r\n", id);
   acc_gyro->read_id(&id);
   printf("LSM6DSL accelerometer & gyroscope = 0x%X\r\n", id);
+  acc_gyro_ext->read_id(&id);
+  printf("LSM6DSOX accelerometer & gyroscope = 0x%X\r\n", id);
 
 #if LCD_DISPLAY
   BSP_LCD_Init();

--- a/LKExp-mbed-x-nucleo-iks01a2/src/show.cpp
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/show.cpp
@@ -72,6 +72,39 @@ namespace show {
         sprintf((char*)lcd_string,"LSM6DSL [gyro/mdps]: %6ld, %6ld, %6ld               ", axes[0], axes[1], axes[2]);
         BSP_LCD_DisplayStringAt(0, 350, (uint8_t*)lcd_string, LEFT_MODE);
     }
+
+void lcd(LSM303AGRMagSensor* magnetometer, HTS221Sensor* hum_temp, LPS22HBSensor* press_temp, LSM6DSOXSensor* acc_gyro_ext, LSM303AGRAccSensor* accelerometer) {
+    float value1, value2;
+    char buffer1[32], buffer2[32];
+    int32_t axes[3];
+    uint8_t lcd_string[100];
+    
+    hum_temp->get_temperature(&value1);
+    hum_temp->get_humidity(&value2);
+    sprintf((char*)lcd_string,"HTS221: [temp] %7s C,   [hum] %s%%               ", print_double(buffer1, value1), print_double(buffer2, value2));
+    BSP_LCD_DisplayStringAt(0, 100, (uint8_t*)lcd_string, LEFT_MODE);
+
+    press_temp->get_temperature(&value1);
+    press_temp->get_pressure(&value2);
+    sprintf((char*)lcd_string,"LPS22HB: [temp] %7s C, [press] %s mbar               ", print_double(buffer1, value1), print_double(buffer2, value2));
+    BSP_LCD_DisplayStringAt(0, 150, (uint8_t*)lcd_string, LEFT_MODE);
+    
+    magnetometer->get_m_axes(axes);
+    sprintf((char*)lcd_string,"LSM303AGR [mag/mgauss]:  %6ld, %6ld, %6ld               ", axes[0], axes[1], axes[2]);
+    BSP_LCD_DisplayStringAt(0, 200, (uint8_t*)lcd_string, LEFT_MODE);
+
+    accelerometer->get_x_axes(axes);
+    sprintf((char*)lcd_string,"LSM303AGR [acc/mg]:  %6ld, %6ld, %6ld               ", axes[0], axes[1], axes[2]);
+    BSP_LCD_DisplayStringAt(0, 250, (uint8_t*)lcd_string, LEFT_MODE);
+
+    acc_gyro_ext->get_x_axes(axes);
+    sprintf((char*)lcd_string,"LSM6DSOX [acc/mg]: %6ld, %6ld, %6ld               ", axes[0], axes[1], axes[2]);
+    BSP_LCD_DisplayStringAt(0, 300, (uint8_t*)lcd_string, LEFT_MODE);
+
+    acc_gyro_ext->get_g_axes(axes);
+    sprintf((char*)lcd_string,"LSM6DSOX [gyro/mdps]: %6ld, %6ld, %6ld               ", axes[0], axes[1], axes[2]);
+    BSP_LCD_DisplayStringAt(0, 350, (uint8_t*)lcd_string, LEFT_MODE);
+}
 #else
     void terminal(LSM303AGRMagSensor* magnetometer, HTS221Sensor* hum_temp, LPS22HBSensor* press_temp, LSM6DSLSensor* acc_gyro, LSM303AGRAccSensor* accelerometer) {
         float value1, value2;
@@ -105,5 +138,38 @@ namespace show {
         printf("---\r\n");
         stdio_mutex.unlock();
     }
+
+void terminal(LSM303AGRMagSensor* magnetometer, HTS221Sensor* hum_temp, LPS22HBSensor* press_temp, LSM6DSOXSensor* acc_gyro_ext, LSM303AGRAccSensor* accelerometer) {
+    float value1, value2;
+    char buffer1[32], buffer2[32];
+    int32_t axes[3];
+    
+    stdio_mutex.lock();
+    printf("\r\n");
+    
+    hum_temp->get_temperature(&value1);
+    hum_temp->get_humidity(&value2);
+    printf("HTS221: [temp] %7s C,   [hum] %s%%\r\n", print_double(buffer1, value1), print_double(buffer2, value2));
+
+    press_temp->get_temperature(&value1);
+    press_temp->get_pressure(&value2);
+    printf("LPS22HB: [temp] %7s C, [press] %s mbar\r\n", print_double(buffer1, value1), print_double(buffer2, value2));
+    printf("---\r\n");
+    
+    magnetometer->get_m_axes(axes);
+    printf("LSM303AGR [mag/mgauss]:  %6ld, %6ld, %6ld\r\n", axes[0], axes[1], axes[2]);
+
+    accelerometer->get_x_axes(axes);
+    printf("LSM303AGR [acc/mg]:  %6ld, %6ld, %6ld\r\n", axes[0], axes[1], axes[2]);
+
+    acc_gyro_ext->get_x_axes(axes);
+    printf("LSM6DSOX [acc/mg]:      %6ld, %6ld, %6ld\r\n", axes[0], axes[1], axes[2]);
+
+    acc_gyro_ext->get_g_axes(axes);
+    printf("LSM6DSOX [gyro/mdps]:   %6ld, %6ld, %6ld\r\n", axes[0], axes[1], axes[2]);
+
+    printf("---\r\n");
+    stdio_mutex.unlock();
+}
 #endif
 }

--- a/LKExp-mbed-x-nucleo-iks01a2/src/show.h
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/show.h
@@ -1,15 +1,19 @@
 #ifndef _SHOW_H_
 #define _SHOW_H_
 
+# define LCD_DISPLAY 1
+
 #include "mbed.h"
-#include "XNucleoIKS01A2.h"
+#include "XNucleoIKS01A2_Extension.h"
 #if LCD_DISPLAY
 #include "stm32f769i_discovery_lcd.h"
 #endif
 
 namespace show {
     void lcd(LSM303AGRMagSensor*, HTS221Sensor*, LPS22HBSensor*, LSM6DSLSensor*, LSM303AGRAccSensor*);
+    void lcd(LSM303AGRMagSensor*, HTS221Sensor*, LPS22HBSensor*, LSM6DSOXSensor*, LSM303AGRAccSensor*);
     void terminal(LSM303AGRMagSensor*, HTS221Sensor*, LPS22HBSensor*, LSM6DSLSensor*, LSM303AGRAccSensor*);
+    void terminal(LSM303AGRMagSensor*, HTS221Sensor*, LPS22HBSensor*, LSM6DSOXSensor*, LSM303AGRAccSensor*);
 }
 extern Mutex stdio_mutex;
 

--- a/LKExp-mbed-x-nucleo-iks01a2/src/x_nucleo_iks01a2_extension_targets.h
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/x_nucleo_iks01a2_extension_targets.h
@@ -1,0 +1,54 @@
+/**
+  ******************************************************************************
+  * @file    x_nucleo_iks01a2_targets.h
+  * @author  CLab
+  * @version V1.0.0
+  * @date    9-August-2016
+  * @brief   This header file is intended to manage the differences between 
+  *          the different supported base-boards which might mount the
+  *          X_NUCLEO_IKS01A2 MEMS Inertial & Environmental Nucleo Expansion Board.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */ 
+
+/* Define to prevent from recursive inclusion --------------------------------*/
+#ifndef _X_NUCLEO_IKS01A2_TARGETS_H_
+#define _X_NUCLEO_IKS01A2_TARGETS_H_
+
+/*** I2C ***/
+/* Use Arduino I2C Connectors */
+#define IKS01A2_PIN_I2C_SDA         (D14)
+#define IKS01A2_PIN_I2C_SCL         (D15)
+
+/* LSM6DSL INT1 */
+#define IKS01A2_PIN_LSM6DSL_INT1     (D4)
+/* LSM6DSL INT2 */
+#define IKS01A2_PIN_LSM6DSL_INT2     (D5)
+
+#endif // _X_NUCLEO_IKS01A2_TARGETS_H_

--- a/LKExp-mbed-x-nucleo-iks01a2/src/x_nucleo_iks01a2_extension_targets.h
+++ b/LKExp-mbed-x-nucleo-iks01a2/src/x_nucleo_iks01a2_extension_targets.h
@@ -38,8 +38,8 @@
   */ 
 
 /* Define to prevent from recursive inclusion --------------------------------*/
-#ifndef _X_NUCLEO_IKS01A2_TARGETS_H_
-#define _X_NUCLEO_IKS01A2_TARGETS_H_
+#ifndef _X_NUCLEO_IKS01A2_TARGETS_EXTENSION_H_
+#define _X_NUCLEO_IKS01A2_TARGETS_EXTENSION_H_
 
 /*** I2C ***/
 /* Use Arduino I2C Connectors */
@@ -51,4 +51,9 @@
 /* LSM6DSL INT2 */
 #define IKS01A2_PIN_LSM6DSL_INT2     (D5)
 
-#endif // _X_NUCLEO_IKS01A2_TARGETS_H_
+/* LSM6DSOX INT1 */
+#define PIN_LSM6DSOX_INT1            (A5)
+/* LSM6DSOX INT2 */
+#define PIN_LSM6DSOX_INT2            (A4)
+
+#endif // _X_NUCLEO_IKS01A2_TARGETS_EXTENSION_H_


### PR DESCRIPTION
Ajout des modifications pour inclure le LSM6DSOX sur la nucleo IKS01A2.
Une nouvelle lib a été refaite en ajoutant le nouveau composant.

⚠️ LSM6DSOX n'est pas reconnu

La réponse lorsque l'ID est demandé est la même avec ou sans le module, à voir s'il s'agit d'un dysfonctionnement matériel ou une mauvaise instantiation ou initialisation.

Le test peut être fait de deux manière:
* Via le terminal avec la commande "screen" (après avoir flashé)
* Via l'écran de la Disco-769

L'ID attendue pour le LSM6DSOX est 0x6C.